### PR TITLE
Use Rust nightly version in release workflow

### DIFF
--- a/.github/workflows/create-release-binary.yml
+++ b/.github/workflows/create-release-binary.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: nightly
         components: rustfmt, clippy
         override: true
         default: true


### PR DESCRIPTION
- Attempts to solve [this error](https://github.com/tellor-io/substrate-parachain-node/actions/runs/4952817150/jobs/8859606730) in the current workflow.