### PR TITLE
Fix tag and release name

### DIFF
--- a/.github/workflows/create-release-binary.yml
+++ b/.github/workflows/create-release-binary.yml
@@ -43,8 +43,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        tag_name: ${{ github.sha }}
+        release_name: Release ${{ github.sha }}
         draft: false
         prerelease: false
 


### PR DESCRIPTION
- Fixes this error [here](https://github.com/tellor-io/substrate-parachain-node/actions/runs/4983391501/jobs/8920344877#step:7:10) by naming the tag and release as the last commit hash