### PR TITLE
Prefix release tag name

### DIFF
--- a/.github/workflows/create-release-binary.yml
+++ b/.github/workflows/create-release-binary.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.sha }}
+        tag_name: release-${{ github.sha }}
         release_name: Release ${{ github.sha }}
         draft: false
         prerelease: false


### PR DESCRIPTION
- Fixes this error [here](https://github.com/tellor-io/substrate-parachain-node/actions/runs/4984395687/jobs/8922667270#step:7:10) by prefixing "release-" to the commit hash